### PR TITLE
Implement Chrome stealth patch script

### DIFF
--- a/chrome_stealth.js
+++ b/chrome_stealth.js
@@ -1,0 +1,82 @@
+// Chrome Stealth Patch - Additional evasion for Cloudflare and other bot detection
+// Based on https://github.com/jonfriesen/playwright-go-stealth/issues/2
+(() => {
+  const windowsPatch = (w) => {
+    w.chrome = {
+      app: {
+        isInstalled: false,
+        InstallState: {
+          DISABLED: "disabled",
+          INSTALLED: "installed",
+          NOT_INSTALLED: "not_installed",
+        },
+        RunningState: {
+          CANNOT_RUN: "cannot_run",
+          READY_TO_RUN: "ready_to_run",
+          RUNNING: "running",
+        },
+      },
+      loadTimes: () => {},
+      csi: () => {},
+    };
+    w.console.debug = () => {};
+    w.console.log = () => {};
+    w.console.context = () => {};
+    w.navigator.permissions.query = new Proxy(navigator.permissions.query, {
+      apply: async function (target, thisArg, args) {
+        try {
+          const result = await Reflect.apply(target, thisArg, args);
+          if (result?.state === "prompt") {
+            Object.defineProperty(result, "state", { value: "denied" });
+          }
+          return Promise.resolve(result);
+        } catch (error) {
+          return Promise.reject(error);
+        }
+      },
+    });
+    Element.prototype._addEventListener = Element.prototype.addEventListener;
+    Element.prototype.addEventListener = function () {
+      let args = [...arguments];
+      let temp = args[1];
+      args[1] = function () {
+        let args2 = [...arguments];
+        args2[0] = Object.assign({}, args2[0]);
+        args2[0].isTrusted = true;
+        return temp(...args2);
+      };
+      return this._addEventListener(...args);
+    };
+  };
+  const cloudflareClicker = (w) => {
+    if (w?.document && w.location.host === "challenges.cloudflare.com") {
+      const targetSelector = "input[type=checkbox]";
+      const observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+          if (mutation.type === "childList") {
+            const addedNodes = Array.from(mutation.addedNodes);
+            for (const addedNode of addedNodes) {
+              if (addedNode.nodeType === addedNode.ELEMENT_NODE) {
+                const node = addedNode?.querySelector(targetSelector);
+                if (node) {
+                  node.parentElement.click();
+                }
+              }
+            }
+          }
+        }
+      });
+
+      const observerOptions = {
+        childList: true,
+        subtree: true,
+      };
+      observer.observe(
+        w.document.documentElement || w.document,
+        observerOptions
+      );
+    }
+  };
+  windowsPatch(window);
+  cloudflareClicker(window);
+})();

--- a/example/main.go
+++ b/example/main.go
@@ -57,8 +57,11 @@ func main() {
 		log.Fatalf("could not create page: %v", err)
 	}
 
-	// Inject stealth script
-	err = stealth.Inject(pageWithStealth)
+	// Inject stealth script with additional Chrome stealth options
+	// This enables extra evasions for Cloudflare and other bot detection
+	err = stealth.InjectWithOptions(pageWithStealth, stealth.Options{
+		ChromeStealth: true,
+	})
 	if err != nil {
 		log.Fatalf("could not inject stealth script: %v", err)
 	}

--- a/stealth.go
+++ b/stealth.go
@@ -9,6 +9,32 @@ import (
 //go:embed "stealth.min.js"
 var StealthJS string
 
+//go:embed "chrome_stealth.js"
+var ChromeStealthJS string
+
+// Options configures which stealth scripts to inject.
+type Options struct {
+	// ChromeStealth enables additional Chrome-specific evasions including:
+	// - Chrome app/runtime object patching
+	// - Console method silencing
+	// - Permissions query modification (changes "prompt" to "denied")
+	// - Event listener isTrusted spoofing
+	// - Automatic Cloudflare challenge checkbox clicking
+	//
+	// This is useful for bypassing additional bot detection mechanisms
+	// that the base stealth script doesn't cover.
+	// See: https://github.com/jonfriesen/playwright-go-stealth/issues/2
+	ChromeStealth bool
+}
+
+// DefaultOptions returns the default stealth options with all features disabled.
+// The base stealth script is always injected by InjectWithOptions.
+func DefaultOptions() Options {
+	return Options{
+		ChromeStealth: false,
+	}
+}
+
 // Inject adds a stealth JavaScript script to the given Playwright page to make it less detectable by automated detection mechanisms.
 //
 // The stealth script modifies various browser characteristics to evade detection by websites that block or track bots. The script is embedded in the Go binary using the //go:embed directive, which includes the contents of the "stealth.min.js" file as the StealthJS variable. Get the latest version of playwright-go-stealth for more up to version os the evasions.
@@ -29,4 +55,46 @@ func Inject(page playwright.Page) error {
 	return page.AddInitScript(playwright.Script{
 		Content: playwright.String(StealthJS),
 	})
+}
+
+// InjectWithOptions adds stealth JavaScript scripts to the given Playwright page
+// with configurable options for additional evasion techniques.
+//
+// The base stealth script (stealth.min.js) is always injected. Additional scripts
+// can be enabled via the Options struct.
+//
+// Usage example:
+//
+//	page, err := browser.NewPage()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	opts := stealth.Options{
+//	    ChromeStealth: true, // Enable additional Chrome evasions
+//	}
+//	err = stealth.InjectWithOptions(page, opts)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// The scripts are injected using AddInitScript to ensure they execute before
+// any other scripts on the page.
+func InjectWithOptions(page playwright.Page, opts Options) error {
+	// Always inject the base stealth script
+	if err := page.AddInitScript(playwright.Script{
+		Content: playwright.String(StealthJS),
+	}); err != nil {
+		return err
+	}
+
+	// Inject optional Chrome stealth script
+	if opts.ChromeStealth {
+		if err := page.AddInitScript(playwright.Script{
+			Content: playwright.String(ChromeStealthJS),
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Adds a new optional Chrome stealth script that provides extra evasions:
- Chrome app/runtime object patching
- Console method silencing
- Permissions query modification (changes "prompt" to "denied")
- Event listener isTrusted spoofing
- Automatic Cloudflare challenge checkbox clicking

Implements InjectWithOptions() alongside existing Inject() for backward compatibility. Users can enable ChromeStealth via Options struct.

Fixes #2 